### PR TITLE
⛑ Fix SVGs that are using <g

### DIFF
--- a/src/Svg.php
+++ b/src/Svg.php
@@ -47,7 +47,7 @@ final class Svg implements Htmlable
             return $contents;
         }
 
-        $svgContent = strip_tags($contents, ['circle', 'ellipse', 'line', 'path', 'polygon', 'polyline', 'rect']);
+        $svgContent = strip_tags($contents, ['circle', 'ellipse', 'line', 'path', 'polygon', 'polyline', 'rect', 'g']);
         $hash = 'icon-'.md5($svgContent);
         $contents = str_replace($svgContent, strtr('<use href=":href"></use>', [':href' => '#'.$hash]), $contents);
         $contents .= <<<BLADE

--- a/tests/SvgTest.php
+++ b/tests/SvgTest.php
@@ -32,8 +32,56 @@ class SvgTest extends TestCase
         $svg = new Svg('heroicon-o-arrow-right', '<svg>'.$svgPath.'</svg>', ['defer' => true]);
 
         $svgHtml = $svg->toHtml();
-        $this->assertStringContainsString('<use href="#icon-'.md5($svgPath).'"></use>', $svgHtml);
-        $this->assertStringContainsString($svgPath, $svgHtml);
+        $this->assertEquals('<svg defer="1"><use href="#icon-8970cc32a6db8f9088d764a8832c411b"></use></svg>
+    @once("icon-8970cc32a6db8f9088d764a8832c411b")
+        @push("bladeicons")
+            <g id="icon-8970cc32a6db8f9088d764a8832c411b">
+                <path d="M14 5l7 7m0 0l-7 7m7-7H3"></path>
+            </g>
+        @endpush
+    @endonce', $svgHtml);
+    }
+
+    /** @test */
+    public function it_can_compile_to_defered_html_with_group()
+    {
+        $svgPath = '<g id="test" transform="translate(1 1)"><path d="M14 5l7 7m0 0l-7 7m7-7H3"></path></g>';
+        $svg = new Svg('heroicon-o-arrow-right', '<svg>'.$svgPath.'</svg>', ['defer' => true]);
+
+        $svgHtml = $svg->toHtml();
+
+        $this->assertEquals('<svg defer="1"><use href="#icon-17c27df6b7d6560d9202829b719225b0"></use></svg>
+    @once("icon-17c27df6b7d6560d9202829b719225b0")
+        @push("bladeicons")
+            <g id="icon-17c27df6b7d6560d9202829b719225b0">
+                <g id="test" transform="translate(1 1)"><path d="M14 5l7 7m0 0l-7 7m7-7H3"></path></g>
+            </g>
+        @endpush
+    @endonce', $svgHtml);
+    }
+
+    /** @test */
+    public function it_can_compile_to_defered_html_with_group_and_whitespace()
+    {
+        $svgPath = '
+<g id="test" transform="translate(1 1)">
+    <path d="M14 5l7 7m0 0l-7 7m7-7H3"></path>
+</g>';
+        $svg = new Svg('heroicon-o-arrow-right', '<svg>'.$svgPath.'</svg>', ['defer' => true]);
+
+        $svgHtml = $svg->toHtml();
+
+        $this->assertEquals('<svg defer="1"><use href="#icon-e691490d4580d7276ba2a39a287f365f"></use></svg>
+    @once("icon-e691490d4580d7276ba2a39a287f365f")
+        @push("bladeicons")
+            <g id="icon-e691490d4580d7276ba2a39a287f365f">
+                
+<g id="test" transform="translate(1 1)">
+    <path d="M14 5l7 7m0 0l-7 7m7-7H3"></path>
+</g>
+            </g>
+        @endpush
+    @endonce', $svgHtml);
     }
 
     /** @test */


### PR DESCRIPTION
👋 

I've noticed that some of my SVGs were not properly deferred. This is caused due the `strip_tags` and content not matching (maybe would be safe to grab the contents between `<svg>` content - if desired I can make regex that could handle this).

This is screenshot from xdebug while I was debugging the bug.

<img width="1287" alt="Snímek obrazovky 2022-09-19 v 20 11 48" src="https://user-images.githubusercontent.com/1878831/191091744-c4e80553-a266-413c-927e-6c51a7ce9d73.png">

I've made the test more strict + added test SVGs with white spaces to make it more safe.

**FYI:**

I would like to change the "hash" to static value, can I make the PR (using attributes)? I would like to use the SVG in React (this would help me to prevent bugs when someone changes the SVG in source code).


Thanks for the package and have a great day,
