### PR TITLE
Fix defer when svg contains style tag

### DIFF
--- a/src/Svg.php
+++ b/src/Svg.php
@@ -47,7 +47,7 @@ final class Svg implements Htmlable
             return $contents;
         }
 
-        $svgContent = strip_tags($contents, ['circle', 'ellipse', 'line', 'path', 'polygon', 'polyline', 'rect', 'g', 'mask', 'defs', 'use']);
+        $svgContent = strip_tags($contents, ['circle', 'ellipse', 'line', 'path', 'polygon', 'polyline', 'rect', 'g', 'mask', 'defs', 'style', 'use']);
         $hash = 'icon-'.(is_string($defer) ? $defer : md5($svgContent));
         $contents = str_replace($svgContent, strtr('<use href=":href"></use>', [':href' => '#'.$hash]), $contents);
         $contents .= <<<BLADE


### PR DESCRIPTION
If svg contains `<style>` the 'defer' does not get updated with the `<use>`.

@indykoning wondering what's the reason for not stripping all the tags?

This looks to have been a similar issue. 
https://github.com/blade-ui-kit/blade-icons/commit/977559507feebba431019abf1b319d71dfdacd95

