### PR TITLE
Apply SVG file filter for Generator by Default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ composer.lock
 vendor
 phpunit.xml
 .phpunit.result.cache
+tests/fixtures/tmp

--- a/src/Generation/IconGenerator.php
+++ b/src/Generation/IconGenerator.php
@@ -8,6 +8,7 @@ use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Support\Stringable;
+use Symfony\Component\Finder\SplFileInfo;
 
 final class IconGenerator
 {
@@ -30,13 +31,10 @@ final class IconGenerator
     {
         foreach ($this->sets as $set) {
             $destination = $this->getDestinationDirectory($set);
-            $files = $this->filesystem->files($set['source']);
-            if (isset($set['fileFilter'])) {
-                $files = array_filter(
-                    $files,
-                    $set['fileFilter']
-                );
-            }
+            $files = array_filter(
+                $this->filesystem->files($set['source']),
+                fn (SplFileInfo $value) => str_ends_with($value->getFilename(), '.svg')
+            );
 
             foreach ($files as $file) {
                 $filename = Str::of($file->getFilename());

--- a/src/Generation/IconGenerator.php
+++ b/src/Generation/IconGenerator.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace BladeUI\Icons\Generation;
 
-use Closure;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;

--- a/src/Generation/IconGenerator.php
+++ b/src/Generation/IconGenerator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace BladeUI\Icons\Generation;
 
+use Closure;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
@@ -30,8 +31,15 @@ final class IconGenerator
     {
         foreach ($this->sets as $set) {
             $destination = $this->getDestinationDirectory($set);
+            $files = $this->filesystem->files($set['source']);
+            if (isset($set['fileFilter'])) {
+                $files = array_filter(
+                    $files,
+                    $set['fileFilter']
+                );
+            }
 
-            foreach ($this->filesystem->files($set['source']) as $file) {
+            foreach ($files as $file) {
                 $filename = Str::of($file->getFilename());
                 $filename = $this->applyPrefixes($set, $filename);
                 $filename = $this->applySuffixes($set, $filename);

--- a/tests/IconGeneratorTest.php
+++ b/tests/IconGeneratorTest.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use BladeUI\Icons\Generation\IconGenerator;
+use Faker\Core\File;
+use Illuminate\Filesystem\Filesystem;
+use RecursiveDirectoryIterator;
+use SplFileInfo;
+
+class IconGeneratorTest extends TestCase
+{
+    const RESULT_DIR = __DIR__ . '/fixtures/tmp';
+
+    private function clearResultsDirectory(): void
+    {
+        $fs = new Filesystem();
+        if ($fs->isDirectory(static::RESULT_DIR)) {
+            $fs->deleteDirectory(static::RESULT_DIR);
+        }
+    }
+
+    /** @test */
+    public function it_can_generate_icon_sets()
+    {
+        IconGenerator::create([
+            [
+                'source' => __DIR__.'/resources/svg',
+                'destination' => static::RESULT_DIR . '/primary',
+            ],
+            [
+                'source' => __DIR__.'/resources/svg/solid',
+                'destination' => static::RESULT_DIR .'/solid',
+            ],
+        ])->generate();
+        $this->assertDirectoryExists(static::RESULT_DIR . '/primary');
+        $this->assertDirectoryExists(static::RESULT_DIR . '/solid');
+        $this->assertFileDoesNotExist(static::RESULT_DIR . '/primary/invalid-extension.txt');
+        $this->assertFileExists(static::RESULT_DIR . '/primary/camera.svg');
+        $this->assertFileExists(static::RESULT_DIR . '/solid/camera.svg');
+
+        $this->clearResultsDirectory();
+    }
+
+    /** @test */
+    public function it_will_clear_icons_before_generation_with_safe_mode_off()
+    {
+        // Run once to generate the "OLD" icons
+        IconGenerator::create([
+            [
+                'source' => __DIR__.'/resources/svg',
+                'destination' => static::RESULT_DIR . '/primary',
+            ],
+            [
+                'source' => __DIR__.'/resources/svg/solid',
+                'destination' => static::RESULT_DIR .'/solid',
+            ],
+        ])->generate();
+        $this->assertDirectoryExists(static::RESULT_DIR . '/primary');
+        $this->assertDirectoryExists(static::RESULT_DIR . '/solid');
+        $this->assertFileExists(static::RESULT_DIR . '/primary/camera.svg');
+        $this->assertFileExists(static::RESULT_DIR . '/solid/camera.svg');
+        // Manually insert an "OLD ICON" that's been "removed".
+        file_put_contents(static::RESULT_DIR . '/primary/cold-beans.svg', 'COOL BEANS!');
+        $this->assertFileExists(static::RESULT_DIR . '/primary/cold-beans.svg');
+
+        // Regenerate with Safe mode ON to verify "old" icons will be kept...
+        IconGenerator::create([
+            [
+                'source' => __DIR__.'/resources/svg',
+                'destination' => static::RESULT_DIR . '/primary',
+                'safe' => true,
+            ],
+            [
+                'source' => __DIR__.'/resources/svg/solid',
+                'destination' => static::RESULT_DIR .'/solid',
+                'safe' => true,
+            ],
+        ])->generate();
+        $this->assertFileExists(static::RESULT_DIR . '/primary/cold-beans.svg');
+
+        // Regenerate the icons with safe feature enabled.
+        IconGenerator::create([
+            [
+                'source' => __DIR__.'/resources/svg',
+                'destination' => static::RESULT_DIR . '/primary',
+            ],
+            [
+                'source' => __DIR__.'/resources/svg/solid',
+                'destination' => static::RESULT_DIR .'/solid',
+            ],
+        ])->generate();
+        $this->assertFileDoesNotExist(static::RESULT_DIR . '/primary/cold-beans.svg');
+
+        $this->clearResultsDirectory();
+    }
+
+    /** @test */
+    public function it_can_use_generator_hooks()
+    {
+        $comment = "<!-- ICONS TEST --->".PHP_EOL;
+        IconGenerator::create([
+            [
+                'source' => __DIR__.'/resources/svg',
+                'destination' => static::RESULT_DIR . '/primary',
+                'after' =>static function (
+                    string $tempFilepath,
+                    array $iconSet,
+                    SplFileInfo $file
+                ) use ($comment) {
+                    $fileContents = file_get_contents($tempFilepath);
+                    file_put_contents($tempFilepath, $comment.$fileContents);
+                },
+            ],
+        ])->generate();
+        $this->assertDirectoryExists(static::RESULT_DIR . '/primary');
+        $this->assertFileExists(static::RESULT_DIR . '/primary/camera.svg');
+
+        $iconContent = file_get_contents(static::RESULT_DIR . '/primary/camera.svg');
+        $this->assertStringStartsWith($comment, $iconContent);
+
+        $this->clearResultsDirectory();
+    }
+
+    /** @test */
+    public function it_will_remove_and_apply_prefixes()
+    {
+        IconGenerator::create([
+            [
+                'source' => __DIR__.'/resources/svg',
+                'destination' => static::RESULT_DIR . '/primary',
+                'input-prefix' => 'zondicon-',
+                'output-prefix' => 'blade-',
+            ],
+        ])->generate();
+        $this->assertDirectoryExists(static::RESULT_DIR . '/primary');
+        $this->assertFileExists(static::RESULT_DIR . '/primary/blade-flag.svg');
+        $this->assertFileExists(static::RESULT_DIR . '/primary/blade-camera.svg');
+        $this->assertFileExists(static::RESULT_DIR . '/primary/blade-foo-camera.svg');
+
+        $this->clearResultsDirectory();
+    }
+
+    /** @test */
+    public function it_will_remove_and_apply_suffixes()
+    {
+        IconGenerator::create([
+            [
+                'source' => __DIR__.'/resources/svg',
+                'destination' => static::RESULT_DIR . '/primary',
+                'input-suffix' => '-camera',
+                'output-suffix' => '-wonky',
+            ],
+        ])->generate();
+        $this->assertDirectoryExists(static::RESULT_DIR . '/primary');
+        $this->assertFileExists(static::RESULT_DIR . '/primary/zondicon-flag-wonky.svg');
+        $this->assertFileExists(static::RESULT_DIR . '/primary/camera-wonky.svg');
+        $this->assertFileExists(static::RESULT_DIR . '/primary/foo-wonky.svg');
+
+        $this->clearResultsDirectory();
+    }
+}

--- a/tests/IconGeneratorTest.php
+++ b/tests/IconGeneratorTest.php
@@ -15,6 +15,7 @@ class IconGeneratorTest extends TestCase
     private function clearResultsDirectory(): void
     {
         $fs = new Filesystem();
+
         if ($fs->isDirectory(static::RESULT_DIR)) {
             $fs->deleteDirectory(static::RESULT_DIR);
         }
@@ -33,6 +34,7 @@ class IconGeneratorTest extends TestCase
                 'destination' => static::RESULT_DIR.'/solid',
             ],
         ])->generate();
+
         $this->assertDirectoryExists(static::RESULT_DIR.'/primary');
         $this->assertDirectoryExists(static::RESULT_DIR.'/solid');
         $this->assertFileDoesNotExist(static::RESULT_DIR.'/primary/invalid-extension.txt');
@@ -56,10 +58,12 @@ class IconGeneratorTest extends TestCase
                 'destination' => static::RESULT_DIR.'/solid',
             ],
         ])->generate();
+
         $this->assertDirectoryExists(static::RESULT_DIR.'/primary');
         $this->assertDirectoryExists(static::RESULT_DIR.'/solid');
         $this->assertFileExists(static::RESULT_DIR.'/primary/camera.svg');
         $this->assertFileExists(static::RESULT_DIR.'/solid/camera.svg');
+
         // Manually insert an "OLD ICON" that's been "removed".
         file_put_contents(static::RESULT_DIR.'/primary/cold-beans.svg', 'COOL BEANS!');
         $this->assertFileExists(static::RESULT_DIR.'/primary/cold-beans.svg');
@@ -77,6 +81,7 @@ class IconGeneratorTest extends TestCase
                 'safe' => true,
             ],
         ])->generate();
+
         $this->assertFileExists(static::RESULT_DIR.'/primary/cold-beans.svg');
 
         // Regenerate the icons with safe feature enabled.
@@ -90,6 +95,7 @@ class IconGeneratorTest extends TestCase
                 'destination' => static::RESULT_DIR.'/solid',
             ],
         ])->generate();
+
         $this->assertFileDoesNotExist(static::RESULT_DIR.'/primary/cold-beans.svg');
 
         $this->clearResultsDirectory();
@@ -99,6 +105,7 @@ class IconGeneratorTest extends TestCase
     public function it_can_use_generator_hooks()
     {
         $comment = '<!-- ICONS TEST --->'.PHP_EOL;
+
         IconGenerator::create([
             [
                 'source' => __DIR__.'/resources/svg',
@@ -113,6 +120,7 @@ class IconGeneratorTest extends TestCase
                 },
             ],
         ])->generate();
+
         $this->assertDirectoryExists(static::RESULT_DIR.'/primary');
         $this->assertFileExists(static::RESULT_DIR.'/primary/camera.svg');
 
@@ -133,6 +141,7 @@ class IconGeneratorTest extends TestCase
                 'output-prefix' => 'blade-',
             ],
         ])->generate();
+
         $this->assertDirectoryExists(static::RESULT_DIR.'/primary');
         $this->assertFileExists(static::RESULT_DIR.'/primary/blade-flag.svg');
         $this->assertFileExists(static::RESULT_DIR.'/primary/blade-camera.svg');
@@ -152,6 +161,7 @@ class IconGeneratorTest extends TestCase
                 'output-suffix' => '-wonky',
             ],
         ])->generate();
+
         $this->assertDirectoryExists(static::RESULT_DIR.'/primary');
         $this->assertFileExists(static::RESULT_DIR.'/primary/zondicon-flag-wonky.svg');
         $this->assertFileExists(static::RESULT_DIR.'/primary/camera-wonky.svg');

--- a/tests/IconGeneratorTest.php
+++ b/tests/IconGeneratorTest.php
@@ -5,14 +5,12 @@ declare(strict_types=1);
 namespace Tests;
 
 use BladeUI\Icons\Generation\IconGenerator;
-use Faker\Core\File;
 use Illuminate\Filesystem\Filesystem;
-use RecursiveDirectoryIterator;
 use SplFileInfo;
 
 class IconGeneratorTest extends TestCase
 {
-    const RESULT_DIR = __DIR__ . '/fixtures/tmp';
+    const RESULT_DIR = __DIR__.'/fixtures/tmp';
 
     private function clearResultsDirectory(): void
     {
@@ -28,18 +26,18 @@ class IconGeneratorTest extends TestCase
         IconGenerator::create([
             [
                 'source' => __DIR__.'/resources/svg',
-                'destination' => static::RESULT_DIR . '/primary',
+                'destination' => static::RESULT_DIR.'/primary',
             ],
             [
                 'source' => __DIR__.'/resources/svg/solid',
-                'destination' => static::RESULT_DIR .'/solid',
+                'destination' => static::RESULT_DIR.'/solid',
             ],
         ])->generate();
-        $this->assertDirectoryExists(static::RESULT_DIR . '/primary');
-        $this->assertDirectoryExists(static::RESULT_DIR . '/solid');
-        $this->assertFileDoesNotExist(static::RESULT_DIR . '/primary/invalid-extension.txt');
-        $this->assertFileExists(static::RESULT_DIR . '/primary/camera.svg');
-        $this->assertFileExists(static::RESULT_DIR . '/solid/camera.svg');
+        $this->assertDirectoryExists(static::RESULT_DIR.'/primary');
+        $this->assertDirectoryExists(static::RESULT_DIR.'/solid');
+        $this->assertFileDoesNotExist(static::RESULT_DIR.'/primary/invalid-extension.txt');
+        $this->assertFileExists(static::RESULT_DIR.'/primary/camera.svg');
+        $this->assertFileExists(static::RESULT_DIR.'/solid/camera.svg');
 
         $this->clearResultsDirectory();
     }
@@ -51,48 +49,48 @@ class IconGeneratorTest extends TestCase
         IconGenerator::create([
             [
                 'source' => __DIR__.'/resources/svg',
-                'destination' => static::RESULT_DIR . '/primary',
+                'destination' => static::RESULT_DIR.'/primary',
             ],
             [
                 'source' => __DIR__.'/resources/svg/solid',
-                'destination' => static::RESULT_DIR .'/solid',
+                'destination' => static::RESULT_DIR.'/solid',
             ],
         ])->generate();
-        $this->assertDirectoryExists(static::RESULT_DIR . '/primary');
-        $this->assertDirectoryExists(static::RESULT_DIR . '/solid');
-        $this->assertFileExists(static::RESULT_DIR . '/primary/camera.svg');
-        $this->assertFileExists(static::RESULT_DIR . '/solid/camera.svg');
+        $this->assertDirectoryExists(static::RESULT_DIR.'/primary');
+        $this->assertDirectoryExists(static::RESULT_DIR.'/solid');
+        $this->assertFileExists(static::RESULT_DIR.'/primary/camera.svg');
+        $this->assertFileExists(static::RESULT_DIR.'/solid/camera.svg');
         // Manually insert an "OLD ICON" that's been "removed".
-        file_put_contents(static::RESULT_DIR . '/primary/cold-beans.svg', 'COOL BEANS!');
-        $this->assertFileExists(static::RESULT_DIR . '/primary/cold-beans.svg');
+        file_put_contents(static::RESULT_DIR.'/primary/cold-beans.svg', 'COOL BEANS!');
+        $this->assertFileExists(static::RESULT_DIR.'/primary/cold-beans.svg');
 
         // Regenerate with Safe mode ON to verify "old" icons will be kept...
         IconGenerator::create([
             [
                 'source' => __DIR__.'/resources/svg',
-                'destination' => static::RESULT_DIR . '/primary',
+                'destination' => static::RESULT_DIR.'/primary',
                 'safe' => true,
             ],
             [
                 'source' => __DIR__.'/resources/svg/solid',
-                'destination' => static::RESULT_DIR .'/solid',
+                'destination' => static::RESULT_DIR.'/solid',
                 'safe' => true,
             ],
         ])->generate();
-        $this->assertFileExists(static::RESULT_DIR . '/primary/cold-beans.svg');
+        $this->assertFileExists(static::RESULT_DIR.'/primary/cold-beans.svg');
 
         // Regenerate the icons with safe feature enabled.
         IconGenerator::create([
             [
                 'source' => __DIR__.'/resources/svg',
-                'destination' => static::RESULT_DIR . '/primary',
+                'destination' => static::RESULT_DIR.'/primary',
             ],
             [
                 'source' => __DIR__.'/resources/svg/solid',
-                'destination' => static::RESULT_DIR .'/solid',
+                'destination' => static::RESULT_DIR.'/solid',
             ],
         ])->generate();
-        $this->assertFileDoesNotExist(static::RESULT_DIR . '/primary/cold-beans.svg');
+        $this->assertFileDoesNotExist(static::RESULT_DIR.'/primary/cold-beans.svg');
 
         $this->clearResultsDirectory();
     }
@@ -100,12 +98,12 @@ class IconGeneratorTest extends TestCase
     /** @test */
     public function it_can_use_generator_hooks()
     {
-        $comment = "<!-- ICONS TEST --->".PHP_EOL;
+        $comment = '<!-- ICONS TEST --->'.PHP_EOL;
         IconGenerator::create([
             [
                 'source' => __DIR__.'/resources/svg',
-                'destination' => static::RESULT_DIR . '/primary',
-                'after' =>static function (
+                'destination' => static::RESULT_DIR.'/primary',
+                'after' => static function (
                     string $tempFilepath,
                     array $iconSet,
                     SplFileInfo $file
@@ -115,10 +113,10 @@ class IconGeneratorTest extends TestCase
                 },
             ],
         ])->generate();
-        $this->assertDirectoryExists(static::RESULT_DIR . '/primary');
-        $this->assertFileExists(static::RESULT_DIR . '/primary/camera.svg');
+        $this->assertDirectoryExists(static::RESULT_DIR.'/primary');
+        $this->assertFileExists(static::RESULT_DIR.'/primary/camera.svg');
 
-        $iconContent = file_get_contents(static::RESULT_DIR . '/primary/camera.svg');
+        $iconContent = file_get_contents(static::RESULT_DIR.'/primary/camera.svg');
         $this->assertStringStartsWith($comment, $iconContent);
 
         $this->clearResultsDirectory();
@@ -130,15 +128,15 @@ class IconGeneratorTest extends TestCase
         IconGenerator::create([
             [
                 'source' => __DIR__.'/resources/svg',
-                'destination' => static::RESULT_DIR . '/primary',
+                'destination' => static::RESULT_DIR.'/primary',
                 'input-prefix' => 'zondicon-',
                 'output-prefix' => 'blade-',
             ],
         ])->generate();
-        $this->assertDirectoryExists(static::RESULT_DIR . '/primary');
-        $this->assertFileExists(static::RESULT_DIR . '/primary/blade-flag.svg');
-        $this->assertFileExists(static::RESULT_DIR . '/primary/blade-camera.svg');
-        $this->assertFileExists(static::RESULT_DIR . '/primary/blade-foo-camera.svg');
+        $this->assertDirectoryExists(static::RESULT_DIR.'/primary');
+        $this->assertFileExists(static::RESULT_DIR.'/primary/blade-flag.svg');
+        $this->assertFileExists(static::RESULT_DIR.'/primary/blade-camera.svg');
+        $this->assertFileExists(static::RESULT_DIR.'/primary/blade-foo-camera.svg');
 
         $this->clearResultsDirectory();
     }
@@ -149,15 +147,15 @@ class IconGeneratorTest extends TestCase
         IconGenerator::create([
             [
                 'source' => __DIR__.'/resources/svg',
-                'destination' => static::RESULT_DIR . '/primary',
+                'destination' => static::RESULT_DIR.'/primary',
                 'input-suffix' => '-camera',
                 'output-suffix' => '-wonky',
             ],
         ])->generate();
-        $this->assertDirectoryExists(static::RESULT_DIR . '/primary');
-        $this->assertFileExists(static::RESULT_DIR . '/primary/zondicon-flag-wonky.svg');
-        $this->assertFileExists(static::RESULT_DIR . '/primary/camera-wonky.svg');
-        $this->assertFileExists(static::RESULT_DIR . '/primary/foo-wonky.svg');
+        $this->assertDirectoryExists(static::RESULT_DIR.'/primary');
+        $this->assertFileExists(static::RESULT_DIR.'/primary/zondicon-flag-wonky.svg');
+        $this->assertFileExists(static::RESULT_DIR.'/primary/camera-wonky.svg');
+        $this->assertFileExists(static::RESULT_DIR.'/primary/foo-wonky.svg');
 
         $this->clearResultsDirectory();
     }


### PR DESCRIPTION
This allows icon package devs to define a filter closure applied to the list of discovered files. If the upstream icon package starts to included non-SVG files in Icon set folders this can filter those out.

## Background

Coming back to some of my icon packages I found some errors when generating them:

```
~/MyGitProjects/blade-lucide-icons
± |main ↑1 U:9 ?:48 ✗| → ./vendor/bin/blade-icons-generate
Starting to generate icons...

Warning: DOMDocument::load(): Start tag expected, '<' not found in /Users/danpock/MyGitProjects/blade-lucide-icons/resources/svg/accessibility.json, line: 1 in /Users/danpock/MyGitProjects/blade-lucide-icons/config/generation.php on line 5

Fatal error: Uncaught Error: Call to a member function removeAttribute() on null in /Users/danpock/MyGitProjects/blade-lucide-icons/config/generation.php:7
```

I've determined this is caused by my "upstream icon" package adding JSON files into the `icons` directory. As such I now need a way to ensure the generator only interacts with the correct files.

This PR modifies the files array to ensure only `.svg` extension files are included in the list passed to the generator.
