### PR TITLE
Add a generator Icon Set config

### DIFF
--- a/src/Generation/IconGenerator.php
+++ b/src/Generation/IconGenerator.php
@@ -26,7 +26,7 @@ final class IconGenerator
     }
 
     /**
-     * @param array<int, IconSetConfig|array<string, mixed>> $configs
+     * @param  array<int, IconSetConfig|array<string, mixed>>  $configs
      * @return static
      */
     public static function create(array $configs): self
@@ -42,6 +42,7 @@ final class IconGenerator
                 $parsed[] = IconSetConfig::tryFromArray($config);
             }
         }
+
         return new self($parsed);
     }
 
@@ -65,7 +66,7 @@ final class IconGenerator
 
                 $this->filesystem->copy($file->getRealPath(), $pathname);
 
-                if (!is_null($set->after)) {
+                if (! is_null($set->after)) {
                     $reflectHook = new ReflectionFunction($set->after);
                     if ($reflectHook->getParameters()[1]->getType()->getName() === 'array') {
                         ($set->after)($pathname, $set->toArray(), $file);

--- a/src/Generation/IconGenerator.php
+++ b/src/Generation/IconGenerator.php
@@ -75,7 +75,7 @@ final class IconGenerator
     {
         $destination = Str::finish($set->destination, DIRECTORY_SEPARATOR);
 
-        if ($set->safe) {
+        if (! $set->safe) {
             $this->filesystem->deleteDirectory($destination);
         }
 

--- a/src/Generation/IconGenerator.php
+++ b/src/Generation/IconGenerator.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace BladeUI\Icons\Generation;
 
 use Illuminate\Filesystem\Filesystem;
-use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Support\Stringable;
 use Symfony\Component\Finder\SplFileInfo;
@@ -14,6 +13,9 @@ final class IconGenerator
 {
     private Filesystem $filesystem;
 
+    /**
+     * @var IconSetConfig[]
+     */
     private array $sets;
 
     public function __construct(array $sets)
@@ -22,17 +24,35 @@ final class IconGenerator
         $this->sets = $sets;
     }
 
-    public static function create(array $config): self
+    /**
+     * @param array<int, IconSetConfig|array<string, mixed>> $configs
+     * @return static
+     */
+    public static function create(array $configs): self
     {
-        return new self($config);
+        /**
+         * @var IconSetConfig[] $parsed
+         */
+        $parsed = [];
+        foreach ($configs as $config) {
+            if ($config instanceof IconSetConfig) {
+                $parsed[] = $config;
+            } else {
+                $parsed[] = IconSetConfig::tryFromArray($config);
+            }
+        }
+        return new self($parsed);
     }
 
     public function generate(): void
     {
+        /**
+         * @var IconSetConfig $set
+         */
         foreach ($this->sets as $set) {
             $destination = $this->getDestinationDirectory($set);
             $files = array_filter(
-                $this->filesystem->files($set['source']),
+                $this->filesystem->files($set->source),
                 fn (SplFileInfo $value) => str_ends_with($value->getFilename(), '.svg')
             );
 
@@ -44,18 +64,18 @@ final class IconGenerator
 
                 $this->filesystem->copy($file->getRealPath(), $pathname);
 
-                if (is_callable($set['after'] ?? null)) {
-                    $set['after']($pathname, $set, $file);
+                if (!is_null($set->after)) {
+                    ($set->after)($pathname, $set, $file);
                 }
             }
         }
     }
 
-    private function getDestinationDirectory(array $set): string
+    private function getDestinationDirectory(IconSetConfig $set): string
     {
-        $destination = Str::finish($set['destination'], DIRECTORY_SEPARATOR);
+        $destination = Str::finish($set->destination, DIRECTORY_SEPARATOR);
 
-        if (! Arr::get($set, 'safe', false)) {
+        if ($set->safe) {
             $this->filesystem->deleteDirectory($destination);
         }
 
@@ -64,27 +84,27 @@ final class IconGenerator
         return $destination;
     }
 
-    private function applyPrefixes($set, Stringable $filename): Stringable
+    private function applyPrefixes(IconSetConfig $set, Stringable $filename): Stringable
     {
-        if ($set['input-prefix'] ?? false) {
-            $filename = $filename->after($set['input-prefix']);
+        if ($set->inputPrefix !== '') {
+            $filename = $filename->after($set->inputPrefix);
         }
 
-        if ($set['output-prefix'] ?? false) {
-            $filename = $filename->prepend($set['output-prefix']);
+        if ($set->outputPrefix !== '') {
+            $filename = $filename->prepend($set->outputPrefix);
         }
 
         return $filename;
     }
 
-    private function applySuffixes($set, Stringable $filename): Stringable
+    private function applySuffixes(IconSetConfig $set, Stringable $filename): Stringable
     {
-        if ($set['input-suffix'] ?? false) {
-            $filename = $filename->replace($set['input-suffix'].'.svg', '.svg');
+        if ($set->inputSuffix !== '') {
+            $filename = $filename->replace($set->inputSuffix.'.svg', '.svg');
         }
 
-        if ($set['output-suffix'] ?? false) {
-            $filename = $filename->replace('.svg', $set['output-suffix'].'.svg');
+        if ($set->outputSuffix ?? false) {
+            $filename = $filename->replace('.svg', $set->outputSuffix.'.svg');
         }
 
         return $filename;

--- a/src/Generation/IconGenerator.php
+++ b/src/Generation/IconGenerator.php
@@ -7,6 +7,7 @@ namespace BladeUI\Icons\Generation;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Str;
 use Illuminate\Support\Stringable;
+use ReflectionFunction;
 use Symfony\Component\Finder\SplFileInfo;
 
 final class IconGenerator
@@ -65,7 +66,12 @@ final class IconGenerator
                 $this->filesystem->copy($file->getRealPath(), $pathname);
 
                 if (!is_null($set->after)) {
-                    ($set->after)($pathname, $set, $file);
+                    $reflectHook = new ReflectionFunction($set->after);
+                    if ($reflectHook->getParameters()[1]->getType()->getName() === 'array') {
+                        ($set->after)($pathname, $set->toArray(), $file);
+                    } else {
+                        ($set->after)($pathname, $set, $file);
+                    }
                 }
             }
         }

--- a/src/Generation/IconSetConfig.php
+++ b/src/Generation/IconSetConfig.php
@@ -4,9 +4,10 @@ namespace BladeUI\Icons\Generation;
 
 use ArrayAccess;
 use Closure;
+use Illuminate\Contracts\Support\Arrayable;
 use SplFileInfo;
 
-class IconSetConfig implements ArrayAccess
+class IconSetConfig implements ArrayAccess, Arrayable
 {
     public string $source;
 
@@ -134,5 +135,20 @@ class IconSetConfig implements ArrayAccess
     {
         // Intentionally unimplemented.
         return;
+    }
+
+    public function toArray()
+    {
+        $array = [
+            'source' => $this->source,
+            'destination' => $this->destination,
+            'input-prefix' => $this->inputPrefix,
+            'output-prefix' => $this->outputPrefix,
+            'input-suffix' => $this->inputSuffix,
+            'output-suffix' => $this->outputSuffix,
+            'safe' => $this->safe,
+            'after' => $this->after,
+        ];
+        return array_filter($array, static function ($value) { return !empty($value);});
     }
 }

--- a/src/Generation/IconSetConfig.php
+++ b/src/Generation/IconSetConfig.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace BladeUI\Icons\Generation;
+
+use Closure;
+use SplFileInfo;
+
+class IconSetConfig
+{
+    public string $source;
+
+    public string $destination;
+
+    public string $inputPrefix;
+
+    public string $outputPrefix;
+
+    public string $inputSuffix;
+
+    public string $outputSuffix;
+
+    public bool $safe;
+
+    /**
+     * @var ?Closure(string, IconSetConfig, SplFileInfo): void
+     */
+    public ?Closure $after;
+
+    private function __construct(
+        string $source,
+        string $destination,
+        string $inputPrefix,
+        string $outputPrefix,
+        string $inputSuffix,
+        string $outputSuffix,
+        bool $safe,
+        ?Closure $after
+    ) {
+        $this->source = $source;
+        $this->destination = $destination;
+        $this->inputPrefix = $inputPrefix;
+        $this->outputPrefix = $outputPrefix;
+        $this->inputSuffix = $inputSuffix;
+        $this->outputSuffix = $outputSuffix;
+        $this->safe = $safe;
+        $this->after = $after;
+    }
+
+    /**
+     * @param string $source Define a source directory for the icon sets. Like a node_modules/ or vendor/ directory.
+     * @param string $destination Define a destination directory for your icons.
+     * @param string $inputPrefix Strip an optional prefix from each source icon name.
+     * @param string $outputPrefix Set an optional prefix to applied to each destination icon name.
+     * @param string $inputSuffix Strip an optional suffix from each source icon name.
+     * @param string $outputSuffix Set an optional suffix to applied to each destination icon name.
+     * @param bool|null $safe Enable "safe" mode which will prevent deletion of old icons.
+     * @param Closure(string, IconSetConfig, SplFileInfo): void|null $after Call an optional callback to manipulate the icon.
+     * @return static
+     */
+    public static function build(
+        string $source,
+        string $destination,
+        string $inputPrefix = '',
+        string $outputPrefix = '',
+        string $inputSuffix = '',
+        string $outputSuffix = '',
+        ?bool $safe = false,
+        ?Closure $after = null
+    ): self
+    {
+        return new self(
+            $source,
+            $destination,
+            $inputPrefix,
+            $outputPrefix,
+            $inputSuffix,
+            $outputSuffix,
+            $safe,
+            $after,
+        );
+    }
+
+    public static function tryFromArray(array $config) : self
+    {
+        if (!isset($config['source'], $config['destination'])) {
+            throw new \RuntimeException('Config must have source and destination set');
+        }
+
+        return self::build(
+            $config['source'],
+            $config['destination'],
+            $config['input-prefix'] ?? '',
+            $config['output-prefix'] ?? '',
+            $config['input-suffix'] ?? '',
+            $config['output-suffix'] ?? '',
+            $config['safe'] ?? false,
+            $config['after'] ?? null,
+        );
+    }
+}

--- a/src/Generation/IconSetConfig.php
+++ b/src/Generation/IconSetConfig.php
@@ -135,7 +135,6 @@ class IconSetConfig implements ArrayAccess, Arrayable
     public function offsetUnset($offset): void
     {
         // Intentionally unimplemented.
-
     }
 
     public function toArray()
@@ -152,7 +151,7 @@ class IconSetConfig implements ArrayAccess, Arrayable
         ];
 
         return array_filter($array, static function ($value) {
-        return ! empty($value);
+            return ! empty($value);
         });
     }
 }

--- a/src/Generation/IconSetConfig.php
+++ b/src/Generation/IconSetConfig.php
@@ -115,7 +115,7 @@ class IconSetConfig implements ArrayAccess, Arrayable
         return property_exists($this, $offset);
     }
 
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         if (in_array($offset, array_keys(static::$arrayKeyMap))) {
             $offset = static::$arrayKeyMap[$offset];
@@ -124,7 +124,7 @@ class IconSetConfig implements ArrayAccess, Arrayable
         return $this->{$offset};
     }
 
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (in_array($offset, array_keys(static::$arrayKeyMap))) {
             $offset = static::$arrayKeyMap[$offset];
@@ -132,7 +132,7 @@ class IconSetConfig implements ArrayAccess, Arrayable
         $this->{$offset} = $value;
     }
 
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         // Intentionally unimplemented.
 

--- a/src/Generation/IconSetConfig.php
+++ b/src/Generation/IconSetConfig.php
@@ -115,6 +115,7 @@ class IconSetConfig implements ArrayAccess, Arrayable
         return property_exists($this, $offset);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset): mixed
     {
         if (in_array($offset, array_keys(static::$arrayKeyMap))) {

--- a/src/Generation/IconSetConfig.php
+++ b/src/Generation/IconSetConfig.php
@@ -2,10 +2,11 @@
 
 namespace BladeUI\Icons\Generation;
 
+use ArrayAccess;
 use Closure;
 use SplFileInfo;
 
-class IconSetConfig
+class IconSetConfig implements ArrayAccess
 {
     public string $source;
 
@@ -20,6 +21,13 @@ class IconSetConfig
     public string $outputSuffix;
 
     public bool $safe;
+
+    private static array $arrayKeyMap = [
+        'input-prefix' => 'inputPrefix',
+        'output-prefix' => 'outputPrefix',
+        'input-suffix' => 'inputSuffix',
+        'output-suffix' => 'outputSuffix',
+    ];
 
     /**
      * @var ?Closure(string, IconSetConfig, SplFileInfo): void
@@ -96,5 +104,35 @@ class IconSetConfig
             $config['safe'] ?? false,
             $config['after'] ?? null,
         );
+    }
+
+    public function offsetExists($offset): bool
+    {
+        if (in_array($offset, array_keys(static::$arrayKeyMap))) {
+            return true;
+        }
+        return property_exists($this, $offset);
+    }
+
+    public function offsetGet($offset)
+    {
+        if (in_array($offset, array_keys(static::$arrayKeyMap))) {
+            $offset = static::$arrayKeyMap[$offset];
+        }
+        return $this->{$offset};
+    }
+
+    public function offsetSet($offset, $value)
+    {
+        if (in_array($offset, array_keys(static::$arrayKeyMap))) {
+            $offset = static::$arrayKeyMap[$offset];
+        }
+        $this->{$offset} = $value;
+    }
+
+    public function offsetUnset($offset)
+    {
+        // Intentionally unimplemented.
+        return;
     }
 }

--- a/src/Generation/IconSetConfig.php
+++ b/src/Generation/IconSetConfig.php
@@ -116,7 +116,7 @@ class IconSetConfig implements ArrayAccess, Arrayable
     }
 
     #[\ReturnTypeWillChange]
-    public function offsetGet($offset): mixed
+    public function offsetGet($offset)
     {
         if (in_array($offset, array_keys(static::$arrayKeyMap))) {
             $offset = static::$arrayKeyMap[$offset];

--- a/src/Generation/IconSetConfig.php
+++ b/src/Generation/IconSetConfig.php
@@ -56,14 +56,14 @@ class IconSetConfig implements ArrayAccess, Arrayable
     }
 
     /**
-     * @param string $source Define a source directory for the icon sets. Like a node_modules/ or vendor/ directory.
-     * @param string $destination Define a destination directory for your icons.
-     * @param string $inputPrefix Strip an optional prefix from each source icon name.
-     * @param string $outputPrefix Set an optional prefix to applied to each destination icon name.
-     * @param string $inputSuffix Strip an optional suffix from each source icon name.
-     * @param string $outputSuffix Set an optional suffix to applied to each destination icon name.
-     * @param bool|null $safe Enable "safe" mode which will prevent deletion of old icons.
-     * @param Closure(string, IconSetConfig, SplFileInfo): void|null $after Call an optional callback to manipulate the icon.
+     * @param  string  $source Define a source directory for the icon sets. Like a node_modules/ or vendor/ directory.
+     * @param  string  $destination Define a destination directory for your icons.
+     * @param  string  $inputPrefix Strip an optional prefix from each source icon name.
+     * @param  string  $outputPrefix Set an optional prefix to applied to each destination icon name.
+     * @param  string  $inputSuffix Strip an optional suffix from each source icon name.
+     * @param  string  $outputSuffix Set an optional suffix to applied to each destination icon name.
+     * @param  bool|null  $safe Enable "safe" mode which will prevent deletion of old icons.
+     * @param  Closure(string, IconSetConfig, SplFileInfo): void|null  $after Call an optional callback to manipulate the icon.
      * @return static
      */
     public static function build(
@@ -75,8 +75,7 @@ class IconSetConfig implements ArrayAccess, Arrayable
         string $outputSuffix = '',
         ?bool $safe = false,
         ?Closure $after = null
-    ): self
-    {
+    ): self {
         return new self(
             $source,
             $destination,
@@ -89,9 +88,9 @@ class IconSetConfig implements ArrayAccess, Arrayable
         );
     }
 
-    public static function tryFromArray(array $config) : self
+    public static function tryFromArray(array $config): self
     {
-        if (!isset($config['source'], $config['destination'])) {
+        if (! isset($config['source'], $config['destination'])) {
             throw new \RuntimeException('Config must have source and destination set');
         }
 
@@ -112,6 +111,7 @@ class IconSetConfig implements ArrayAccess, Arrayable
         if (in_array($offset, array_keys(static::$arrayKeyMap))) {
             return true;
         }
+
         return property_exists($this, $offset);
     }
 
@@ -120,6 +120,7 @@ class IconSetConfig implements ArrayAccess, Arrayable
         if (in_array($offset, array_keys(static::$arrayKeyMap))) {
             $offset = static::$arrayKeyMap[$offset];
         }
+
         return $this->{$offset};
     }
 
@@ -134,7 +135,7 @@ class IconSetConfig implements ArrayAccess, Arrayable
     public function offsetUnset($offset)
     {
         // Intentionally unimplemented.
-        return;
+
     }
 
     public function toArray()
@@ -149,6 +150,9 @@ class IconSetConfig implements ArrayAccess, Arrayable
             'safe' => $this->safe,
             'after' => $this->after,
         ];
-        return array_filter($array, static function ($value) { return !empty($value);});
+
+        return array_filter($array, static function ($value) {
+        return ! empty($value);
+        });
     }
 }

--- a/tests/IconGeneratorTest.php
+++ b/tests/IconGeneratorTest.php
@@ -170,4 +170,62 @@ class IconGeneratorTest extends TestCase
 
         $this->clearResultsDirectory();
     }
+
+    /** @test */
+    public function it_can_use_generator_config_with_old_hooks()
+    {
+        $comment = '<!-- ICONS TEST --->'.PHP_EOL;
+
+        $tests = $this;
+        IconGenerator::create([
+            [
+                'source' => __DIR__.'/resources/svg',
+                'destination' => static::RESULT_DIR.'/primary',
+                'input-suffix' => '-camera',
+                'output-suffix' => '-wonky',
+                'after' => function (
+                    $tempFilepath,
+                    $iconSet,
+                    $file
+                ) use ($comment) {
+                    $fileContents = file_get_contents($tempFilepath);
+                    $this->assertIsString($iconSet['input-suffix']);
+                    $this->assertIsString($iconSet['output-suffix']);
+                    $this->assertEmpty($iconSet['output-prefix']);
+                    $this->assertEquals($iconSet->inputSuffix, $iconSet['input-suffix']);
+                    file_put_contents($tempFilepath, $comment.$fileContents);
+                },
+            ],
+        ])->generate();
+
+        $this->assertDirectoryExists(static::RESULT_DIR.'/primary');
+        $this->assertFileExists(static::RESULT_DIR.'/primary/camera-wonky.svg');
+
+        $iconContent = file_get_contents(static::RESULT_DIR.'/primary/camera-wonky.svg');
+        $this->assertStringStartsWith($comment, $iconContent);
+
+        $this->clearResultsDirectory();
+    }
+
+    /** @test */
+    public function it_can_use_icon_set_configs()
+    {
+        IconGenerator::create([
+            IconSetConfig::build(
+                __DIR__.'/resources/svg',
+                static::RESULT_DIR.'/primary',
+                'zondicon-',
+                '',
+                '',
+                '-blade',
+            ),
+        ])->generate();
+
+        $this->assertDirectoryExists(static::RESULT_DIR.'/primary');
+        $this->assertFileExists(static::RESULT_DIR.'/primary/flag-blade.svg');
+        $this->assertFileExists(static::RESULT_DIR.'/primary/camera-blade.svg');
+        $this->assertFileExists(static::RESULT_DIR.'/primary/foo-camera-blade.svg');
+
+        $this->clearResultsDirectory();
+    }
 }

--- a/tests/IconGeneratorTest.php
+++ b/tests/IconGeneratorTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests;
 
 use BladeUI\Icons\Generation\IconGenerator;
+use BladeUI\Icons\Generation\IconSetConfig;
 use Illuminate\Filesystem\Filesystem;
 use SplFileInfo;
 
@@ -112,7 +113,7 @@ class IconGeneratorTest extends TestCase
                 'destination' => static::RESULT_DIR.'/primary',
                 'after' => static function (
                     string $tempFilepath,
-                    array $iconSet,
+                    IconSetConfig $iconSet,
                     SplFileInfo $file
                 ) use ($comment) {
                     $fileContents = file_get_contents($tempFilepath);

--- a/tests/IconGeneratorTest.php
+++ b/tests/IconGeneratorTest.php
@@ -111,12 +111,13 @@ class IconGeneratorTest extends TestCase
             [
                 'source' => __DIR__.'/resources/svg',
                 'destination' => static::RESULT_DIR.'/primary',
-                'after' => static function (
+                'after' => function (
                     string $tempFilepath,
                     IconSetConfig $iconSet,
                     SplFileInfo $file
                 ) use ($comment) {
                     $fileContents = file_get_contents($tempFilepath);
+                    $this->assertEquals($iconSet->inputSuffix, $iconSet['input-suffix']); // Verify property and array access work the same...
                     file_put_contents($tempFilepath, $comment.$fileContents);
                 },
             ],
@@ -184,15 +185,14 @@ class IconGeneratorTest extends TestCase
                 'input-suffix' => '-camera',
                 'output-suffix' => '-wonky',
                 'after' => function (
-                    $tempFilepath,
-                    $iconSet,
-                    $file
+                    string $tempFilepath,
+                    array $iconSet,
+                    SplFileInfo $file
                 ) use ($comment) {
                     $fileContents = file_get_contents($tempFilepath);
                     $this->assertIsString($iconSet['input-suffix']);
                     $this->assertIsString($iconSet['output-suffix']);
-                    $this->assertEmpty($iconSet['output-prefix']);
-                    $this->assertEquals($iconSet->inputSuffix, $iconSet['input-suffix']);
+                    $this->assertArrayNotHasKey('output-prefix', $iconSet);
                     file_put_contents($tempFilepath, $comment.$fileContents);
                 },
             ],


### PR DESCRIPTION
This change adds in a new `IconSetConfig` that authors can use to more configure their icon sets.
With this they have easier to use DX for the options provided by icon set configs.

After this change icon sets can be configured with:

```
return [
    IconSetConfig::build(
        source: __DIR__.'/../lucide/icons',
        destination: __DIR__.'/../resources/svg',
        safe: true,
        after: $svgNormalization,
    ),
];
```

Before:
```
return [
    [
        'source' => __DIR__.'/../lucide/icons',
        'destination' => __DIR__.'/../resources/svg',
        'after' => $svgNormalization,
        'safe' => true,
    ],
];
```

Example PRs for icon packages: 
* https://github.com/mallardduck/blade-lucide-icons/pull/2/files
* https://github.com/ublabs/blade-simple-icons/pull/5/files