### PR TITLE
📝 Add `blade-filetype-icons` to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ We're not accepting requests to build new icon packages ourselves but you can [s
 - [Blade Evil Icons](https://github.com/codeat3/blade-evil-icons) by [Swapnil Sarwe](https://github.com/swapnilsarwe)
 - [Blade Feather Icons](https://github.com/brunocfalcao/blade-feather-icons) by [Bruno Falcão](https://github.com/brunocfalcao)
 - [Blade File Icons](https://github.com/codeat3/blade-file-icons) by [Swapnil Sarwe](https://github.com/swapnilsarwe)
+- [Blade File Type Icons](https://github.com/log1x/blade-filetype-icons) by [Brandon Nifong](https://github.com/log1x)
 - [Blade FluentUi System Icons](https://github.com/codeat3/blade-fluentui-system-icons) by [Swapnil Sarwe](https://github.com/swapnilsarwe)
 - [Blade Font Audio](https://github.com/codeat3/blade-fontaudio) by [Swapnil Sarwe](https://github.com/swapnilsarwe)
 - [Blade Font Awesome](https://github.com/owenvoke/blade-fontawesome) by [Owen Voke](https://github.com/owenvoke)


### PR DESCRIPTION
This PR adds https://github.com/Log1x/blade-filetype-icons to the README which contains over 1000 file type (or file extension) icons generated from https://github.com/dmhendricks/file-icon-vectors