### PR TITLE
docs: restrict deferring icons to the component

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,6 +428,8 @@ This will push the icons to the stack "bladeicons", you should load this stack a
 </html>
 ```
 
+Deferring icons is only possible using the `<x-icon>` component. This [feature doesn't work](https://github.com/blade-ui-kit/blade-icons/issues/194#issuecomment-1175156423) with the `@svg` Blade directive or the `svg()` helper function.
+
 ##### Using deferred icons in JavaScript
 
 You can re-use your icons from blade in your JavaScript rendered views by providing a custom defer value that will be used as an identifier:


### PR DESCRIPTION
small hint, that his feature doesn't work with the blade directive or the helper function

<!--
Please only send a pull request to the latest release branch.

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; etc.

If applicable, also send a PR to the docs for the new change you're submitting.
-->
