### PR TITLE
Icon deferring; match all SVG tags

### DIFF
--- a/src/Svg.php
+++ b/src/Svg.php
@@ -54,7 +54,7 @@ final class Svg implements Htmlable
         $svgContent = Str::of($contents)
             ->replaceMatches('/<svg[^>]*>/', '')
             ->replaceMatches('/<\/svg>/', '')
-            ->toString();
+            ->__toString();
 
         // Force Unix line endings for hash.
         $hashContent = str_replace(PHP_EOL, "\n", $svgContent);

--- a/src/Svg.php
+++ b/src/Svg.php
@@ -6,6 +6,7 @@ namespace BladeUI\Icons;
 
 use BladeUI\Icons\Concerns\RendersAttributes;
 use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Support\Str;
 
 final class Svg implements Htmlable
 {
@@ -50,7 +51,7 @@ final class Svg implements Htmlable
             return $contents;
         }
 
-        $svgContent = str($contents)
+        $svgContent = Str::of($contents)
             ->replaceMatches('/<svg[^>]*>/', '')
             ->replaceMatches('/<\/svg>/', '')
             ->toString();

--- a/src/Svg.php
+++ b/src/Svg.php
@@ -50,7 +50,10 @@ final class Svg implements Htmlable
             return $contents;
         }
 
-        $svgContent = strip_tags($contents, ['circle', 'ellipse', 'line', 'path', 'polygon', 'polyline', 'rect', 'g', 'mask', 'defs', 'use']);
+        $svgContent = str($contents)
+            ->replaceMatches('/<svg[^>]*>/', '')
+            ->replaceMatches('/<\/svg>/', '')
+            ->toString();
 
         // Force Unix line endings for hash.
         $hashContent = str_replace(PHP_EOL, "\n", $svgContent);


### PR DESCRIPTION
- Initially created with a few common tags: https://github.com/blade-ui-kit/blade-icons/pull/191/files#diff-c17f4a19b6b187c3f1e3c05b299f088d65696dc40479b19d3dc96197f44c05c5R50
- Later on it's extended with: https://github.com/blade-ui-kit/blade-icons/pull/200/files#diff-c17f4a19b6b187c3f1e3c05b299f088d65696dc40479b19d3dc96197f44c05c5R50
- And even more tags: https://github.com/blade-ui-kit/blade-icons/pull/202/files#diff-c17f4a19b6b187c3f1e3c05b299f088d65696dc40479b19d3dc96197f44c05c5R50
- But there are way more: https://developer.mozilla.org/en-US/docs/Web/SVG/Element

With this PR it doesn't matter anymore, every tag works.