### PR TITLE
Accessible SVG icons: Add title tag inside SVG if the title attribute is set

### DIFF
--- a/README.md
+++ b/README.md
@@ -540,6 +540,38 @@ If you'd like, you can use the `svg` helper to expose a fluent syntax for settin
 {{ svg('camera')->id('settings-icon')->dataFoo('bar')->dataBaz() }}
 ```
 
+### Accessibility
+
+If the icon should have semantic meaning, a text alternative can be added with the title attribute. Refer to the [Usage](https://github.com/blade-ui-kit/blade-icons?tab=readme-ov-file#usage) section of this documentation to learn how to add an attribute.
+
+For almost all use cases, your icon will be assuming the role of an image. This means that deciding on if your icon has any semantic meaning, or what that semantic meaning is, you can use the [WCAG alt text decision tree](https://www.w3.org/WAI/tutorials/images/decision-tree/).
+
+If your icon has semantic meaning, using the title attribute will apply the following features to the SVG element:
+
+- Child element of `<title>` with a unique ID containing the value that was passed
+- `title` attribute containing the value that was passed
+- `role="img"`
+- `aria-labelledby` to refer to the unique ID of the title element
+
+Example result:
+
+```html
+<svg 
+	 title="Camera" 
+	 role="img" 
+	 aria-labelledby="svg-inline--title-ajx18rtJBjSu" 
+	 xmlns="http://www.w3.org/2000/svg"
+	 viewBox="0 0 448 512"
+>
+	<title id="svg-inline--title-ajx18rtJBjSu">
+		Camera
+	</title>
+	<path fill="currentColor" d="M438.6 278.6c12.5-12.5 12.5-32.8 0-45.3l-160-160c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L338.8 224 32 224c-17.7 0-32 14.3-32 32s14.3 32 32 32l306.7 0L233.4 393.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0l160-160z"></path>
+</svg>  
+```
+
+If your icon does not have semantic meaning, you may want to hide the icon to reduce overall document clutter. You may do this by adding `aria-hidden="true"` to your icon.
+
 ## Building Packages
 
 If you're interested in building your own third party package to integrate an icon set, it's pretty easy to do so. We've created [a template repo for you to get started with](https://github.com/blade-ui-kit/blade-icons-template). You can find the getting started instructions in its readme.

--- a/README.md
+++ b/README.md
@@ -542,7 +542,7 @@ If you'd like, you can use the `svg` helper to expose a fluent syntax for settin
 
 ### Accessibility
 
-If the icon should have semantic meaning, a text alternative can be added with the title attribute. Refer to the [Usage](https://github.com/blade-ui-kit/blade-icons?tab=readme-ov-file#usage) section of this documentation to learn how to add an attribute.
+If the icon should have semantic meaning, a text alternative can be added with the title attribute. Refer to the [Usage](https://github.com/blade-ui-kit/blade-icons#usage) section of this documentation to learn how to add an attribute.
 
 For almost all use cases, your icon will be assuming the role of an image. This means that deciding on if your icon has any semantic meaning, or what that semantic meaning is, you can use the [WCAG alt text decision tree](https://www.w3.org/WAI/tutorials/images/decision-tree/).
 

--- a/README.md
+++ b/README.md
@@ -553,6 +553,14 @@ If your icon has semantic meaning, using the title attribute will apply the foll
 - `role="img"`
 - `aria-labelledby` to refer to the unique ID of the title element
 
+Example usage:
+
+```blade
+<x-icon-camera title="camera" />
+
+@svg('camera', ['title' => 'camera'])
+```
+
 Example result:
 
 ```html

--- a/src/Svg.php
+++ b/src/Svg.php
@@ -41,13 +41,13 @@ final class Svg implements Htmlable
      * To comply with accessibility standards, SVGs should have a title element.
      * Check accessibility patterns for icons: https://www.deque.com/blog/creating-accessible-svgs/
      */
-    public function addTitle(): string
+    public function addTitle(string $title): string
     {
         // generate a random id for the title element
         $titleId = 'svg-inline--title-'.Str::random(10);
 
         // create title element
-        $title = '<title id='.$titleId.'>'.$this->attributes['title'].'</title>';
+        $title = '<title id='.$titleId.'>'.$title.'</title>';
 
         // add aria-labelledby attribute to svg element
         $this->attributes['aria-labelledby'] = $titleId;
@@ -60,7 +60,7 @@ final class Svg implements Htmlable
     {
         // Check if the title attribute is set and add a title element to the SVG
         if (array_key_exists('title', $this->attributes)) {
-            $this->contents = $this->addTitle();
+            $this->contents = $this->addTitle($this->attributes['title']);
         }
 
         return str_replace(

--- a/src/Svg.php
+++ b/src/Svg.php
@@ -52,6 +52,9 @@ final class Svg implements Htmlable
         // add aria-labelledby attribute to svg element
         $this->attributes['aria-labelledby'] = $titleId;
 
+        // add role attribute to svg element
+        $this->attributes['role'] = 'img';
+
         // add title element to svg
         return preg_replace('/<svg[^>]*>/', "$0$titleElement", $this->contents);
     }

--- a/src/Svg.php
+++ b/src/Svg.php
@@ -44,13 +44,13 @@ final class Svg implements Htmlable
     public function addTitle(): string
     {
         // generate a random id for the title element
-        $title_id = 'svg-inline--title-'.Str::random(10);
+        $titleId = 'svg-inline--title-'.Str::random(10);
 
         // create title element
-        $title = '<title id='.$title_id.'>'.$this->attributes['title'].'</title>';
+        $title = '<title id='.$titleId.'>'.$this->attributes['title'].'</title>';
 
         // add aria-labelledby attribute to svg element
-        $this->attributes['aria-labelledby'] = $title_id;
+        $this->attributes['aria-labelledby'] = $titleId;
 
         // add title element to svg
         return preg_replace('/<svg .+?(>)/', "$0 $title", $this->contents);

--- a/src/Svg.php
+++ b/src/Svg.php
@@ -47,13 +47,13 @@ final class Svg implements Htmlable
         $titleId = 'svg-inline--title-'.Str::random(10);
 
         // create title element
-        $titleElement = '<title id='.$titleId.'>'.$title.'</title>';
+        $titleElement = '<title id="'.$titleId.'">'.$title.'</title>';
 
         // add aria-labelledby attribute to svg element
         $this->attributes['aria-labelledby'] = $titleId;
 
         // add title element to svg
-        return preg_replace('/<svg .+?(>)/', "$0 $titleElement", $this->contents);
+        return preg_replace('/<svg[^>]*>/', "$0$titleElement", $this->contents);
     }
 
     public function toHtml(): string

--- a/src/Svg.php
+++ b/src/Svg.php
@@ -6,6 +6,7 @@ namespace BladeUI\Icons;
 
 use BladeUI\Icons\Concerns\RendersAttributes;
 use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Support\Str;
 
 final class Svg implements Htmlable
 {
@@ -35,8 +36,33 @@ final class Svg implements Htmlable
         return $this->contents;
     }
 
+    /**
+     * This method adds a title element and an aria-labelledby attribute to the SVG.
+     * To comply with accessibility standards, SVGs should have a title element.
+     * Check accessibility patterns for icons: https://www.deque.com/blog/creating-accessible-svgs/
+     */
+    public function addTitle(): string
+    {
+        // generate a random id for the title element
+        $title_id = 'svg-inline--title-'.Str::random(10);
+
+        // create title element
+        $title = '<title id='.$title_id.'>'.$this->attributes['title'].'</title>';
+
+        // add aria-labelledby attribute to svg element
+        $this->attributes['aria-labelledby'] = $title_id;
+
+        // add title element to svg
+        return preg_replace('/<svg .+?(>)/', "$0 $title", $this->contents);
+    }
+
     public function toHtml(): string
     {
+        // Check if the title attribute is set and add a title element to the SVG
+        if (array_key_exists('title', $this->attributes)) {
+            $this->contents = $this->addTitle();
+        }
+
         return str_replace(
             '<svg',
             sprintf('<svg%s', $this->renderAttributes()),

--- a/src/Svg.php
+++ b/src/Svg.php
@@ -47,13 +47,13 @@ final class Svg implements Htmlable
         $titleId = 'svg-inline--title-'.Str::random(10);
 
         // create title element
-        $title = '<title id='.$titleId.'>'.$title.'</title>';
+        $titleElement = '<title id='.$titleId.'>'.$title.'</title>';
 
         // add aria-labelledby attribute to svg element
         $this->attributes['aria-labelledby'] = $titleId;
 
         // add title element to svg
-        return preg_replace('/<svg .+?(>)/', "$0 $title", $this->contents);
+        return preg_replace('/<svg .+?(>)/', "$0 $titleElement", $this->contents);
     }
 
     public function toHtml(): string

--- a/tests/SvgTest.php
+++ b/tests/SvgTest.php
@@ -199,4 +199,21 @@ class SvgTest extends TestCase
 
         $this->assertSame('<svg class="icon" style="color: #fff" data-foo></svg>', $svg->toHtml());
     }
+
+    /** @test */
+    public function it_can_add_title_tag_if_title_attribute_is_passed()
+    {
+        $svg = new Svg('heroicon-s-camera', '<svg></svg>', ['title' => 'Camera']);
+
+        $this->assertStringContainsString('><title id="svg-inline--title-', $svg->toHtml());
+        $this->assertStringContainsString('</title></svg>', $svg->toHtml());
+    }
+
+    /** @test */
+    public function it_can_add_aria_labelledby_attribute_if_title_attribute_is_passed()
+    {
+        $svg = new Svg('heroicon-s-camera', '<svg></svg>', ['title' => 'Camera']);
+
+        $this->assertStringContainsString('aria-labelledby="svg-inline--title-', $svg->toHtml());
+    }
 }

--- a/tests/SvgTest.php
+++ b/tests/SvgTest.php
@@ -210,10 +210,11 @@ class SvgTest extends TestCase
     }
 
     /** @test */
-    public function it_can_add_aria_labelledby_attribute_if_title_attribute_is_passed()
+    public function it_can_add_aria_labelledby_and_role_attributes_if_title_attribute_is_passed()
     {
         $svg = new Svg('heroicon-s-camera', '<svg></svg>', ['title' => 'Camera']);
 
         $this->assertStringContainsString('aria-labelledby="svg-inline--title-', $svg->toHtml());
+        $this->assertStringContainsString('role="img">', $svg->toHtml());
     }
 }


### PR DESCRIPTION
Heya!  👋🏼 First time contributor here!

Considering WCAG accessibility compliance, semantic icons require alternate text. Ref: [FontAwesome Documentation](https://docs.fontawesome.com/web/dig-deeper/accessibility).

We could add a `<title>` tag under SVG element and an aria-labelledby attribute to meet compliance requirements. See pattern 8 on [Deque Best Practices](https://www.deque.com/blog/creating-accessible-svgs/).

For example, 

**This component:**
```html
<x-icon-solid.camera title="camera" />
```

**Could result in the following markup:**
```html
<svg class="svg-inline--fa fa-arrow-right" aria-labelledby="svg-inline--title-ajx18rtJBjSu" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512">

<title id="svg-inline--title-ajx18rtJBjSu">camera</title>

<path fill="currentColor" d="M438.6 278.6c12.5-12.5 12.5-32.8 0-45.3l-160-160c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L338.8 224 32 224c-17.7 0-32 14.3-32 32s14.3 32 32 32l306.7 0L233.4 393.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0l160-160z"></path>

</svg>
```
 
I am trying to incorporate this package in our agencie's workflow but cannot get accessibility team to sign off until we have a way to make this compliant. I am open to suggestions and looking forward to contribute!