### PR TITLE
Consistent console messages

### DIFF
--- a/src/Console/CacheCommand.php
+++ b/src/Console/CacheCommand.php
@@ -8,6 +8,7 @@ use BladeUI\Icons\Factory;
 use BladeUI\Icons\IconsManifest;
 use Illuminate\Console\Command;
 
+#[AsCommand(name: 'icons:cache')]
 final class CacheCommand extends Command
 {
     /**
@@ -24,12 +25,15 @@ final class CacheCommand extends Command
      */
     protected $description = 'Discover icon sets and generate a manifest file';
 
-    public function handle(Factory $factory, IconsManifest $manifest): int
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle(Factory $factory, IconsManifest $manifest)
     {
         $manifest->write($factory->all());
 
-        $this->info('Blade icons manifest file generated successfully!');
-
-        return 0;
+        $this->component->info('Blade icons cached successfully.');
     }
 }

--- a/src/Console/CacheCommand.php
+++ b/src/Console/CacheCommand.php
@@ -26,15 +26,12 @@ final class CacheCommand extends Command
      */
     protected $description = 'Discover icon sets and generate a manifest file';
 
-    /**
-     * Execute the console command.
-     *
-     * @return mixed
-     */
-    public function handle(Factory $factory, IconsManifest $manifest)
+    public function handle(Factory $factory, IconsManifest $manifest): int
     {
         $manifest->write($factory->all());
 
         $this->component->info('Blade icons cached successfully.');
+
+        return 0;
     }
 }

--- a/src/Console/CacheCommand.php
+++ b/src/Console/CacheCommand.php
@@ -7,6 +7,7 @@ namespace BladeUI\Icons\Console;
 use BladeUI\Icons\Factory;
 use BladeUI\Icons\IconsManifest;
 use Illuminate\Console\Command;
+use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'icons:cache')]
 final class CacheCommand extends Command

--- a/src/Console/CacheCommand.php
+++ b/src/Console/CacheCommand.php
@@ -30,7 +30,7 @@ final class CacheCommand extends Command
     {
         $manifest->write($factory->all());
 
-        $this->component->info('Blade icons cached successfully.');
+        $this->components->info('Blade icons cached successfully.');
 
         return 0;
     }

--- a/src/Console/ClearCommand.php
+++ b/src/Console/ClearCommand.php
@@ -25,7 +25,6 @@ final class ClearCommand extends Command
      */
     protected $description = 'Remove the blade icons manifest file';
 
-    
     public function handle(IconsManifest $manifest): int
     {
         $manifest->delete();

--- a/src/Console/ClearCommand.php
+++ b/src/Console/ClearCommand.php
@@ -6,7 +6,9 @@ namespace BladeUI\Icons\Console;
 
 use BladeUI\Icons\IconsManifest;
 use Illuminate\Console\Command;
+use Symfony\Component\Console\Attribute\AsCommand;
 
+#[AsCommand(name: 'icons:clear')]
 final class ClearCommand extends Command
 {
     /**
@@ -23,11 +25,12 @@ final class ClearCommand extends Command
      */
     protected $description = 'Remove the blade icons manifest file';
 
+    
     public function handle(IconsManifest $manifest): int
     {
         $manifest->delete();
-
-        $this->info('Blade icons manifest file cleared!');
+        
+        $this->components->info('Cached blade icons cleared successfully.');
 
         return 0;
     }


### PR DESCRIPTION
This is a purely aesthetic change, to make the console output more consistent with Laravel core caching commands.

It scratches my own itch, so I don't see this mismatch in my deployment output 😄 

![CleanShot 2024-11-11 at 21 39 58@2x](https://github.com/user-attachments/assets/e1df1a8b-ef77-46ca-9bf5-bf02d65084a8)

(Apologies for the multiple commits, first time using Github to fork/edit/PR!)
