### PR TITLE
Make caching console messages consistent with Laravel core

### DIFF
--- a/src/Console/CacheCommand.php
+++ b/src/Console/CacheCommand.php
@@ -28,7 +28,7 @@ final class CacheCommand extends Command
     {
         $manifest->write($factory->all());
 
-        $this->info('Blade icons manifest file generated successfully!');
+        $this->components->info('Blade icons cached successfully.');
 
         return 0;
     }

--- a/src/Console/ClearCommand.php
+++ b/src/Console/ClearCommand.php
@@ -27,7 +27,7 @@ final class ClearCommand extends Command
     {
         $manifest->delete();
 
-        $this->info('Blade icons manifest file cleared!');
+        $this->components->info('Cached blade icons cleared successfully.');
 
         return 0;
     }

--- a/tests/CachingTest.php
+++ b/tests/CachingTest.php
@@ -6,11 +6,12 @@ namespace Tests;
 
 class CachingTest extends TestCase
 {
+    
     /** @test */
     public function it_can_create_a_cache_file()
     {
         $this->artisan('icons:cache')
-            ->expectsOutput('Blade icons manifest file generated successfully!')
+            ->expectsOutput("\n   INFO  Blade icons cached successfully.  \n")
             ->assertExitCode(0);
     }
 
@@ -18,7 +19,7 @@ class CachingTest extends TestCase
     public function it_can_clear_the_cache()
     {
         $this->artisan('icons:clear')
-            ->expectsOutput('Blade icons manifest file cleared!')
+            ->expectsOutput("\n   INFO  Cached blade icons cleared successfully.  \n")
             ->assertExitCode(0);
     }
 }


### PR DESCRIPTION
This is a purely aesthetic change, to make the console output more consistent with Laravel core caching commands. Also updates the related tests.

It scratches my own itch, so I don't see this mismatch in my deployment output 😄

![CleanShot 2024-11-11 at 21 39 58@2x](https://github.com/user-attachments/assets/64d4ea9c-c479-4851-8fde-6018159e9483)
