### PR TITLE
Modify component registration in console commands #286

### DIFF
--- a/src/BladeIconsServiceProvider.php
+++ b/src/BladeIconsServiceProvider.php
@@ -70,6 +70,8 @@ final class BladeIconsServiceProvider extends ServiceProvider
         // that may compile views before ViewFactory is resolved
         if ($this->app->runningInConsole() && ! $this->app->environment('testing')) {
             $this->app->booted(function (Application $app) {
+                // Only register components for commands that compile views, to avoid                                                                                                                                                                                                                                                      
+                // scanning all icon files on every CLI invocation.  
                 if (in_array($_SERVER['argv'][1] ?? null, ['optimize', 'view:cache', 'icons:cache'])) {
                     try {
                         $app->make(Factory::class)->registerComponents();

--- a/src/BladeIconsServiceProvider.php
+++ b/src/BladeIconsServiceProvider.php
@@ -70,10 +70,10 @@ final class BladeIconsServiceProvider extends ServiceProvider
         // that may compile views before ViewFactory is resolved
         if ($this->app->runningInConsole() && ! $this->app->environment('testing')) {
             $this->app->booted(function (Application $app) {
-                try {
-                    $app->make(Factory::class)->registerComponents();
-                } catch (\Exception $e) {
-                    // Silently fail if factory isn't ready yet
+                if (in_array($_SERVER['argv'][1] ?? null, ['optimize', 'view:cache', 'icons:cache'])) {
+                    try {
+                        $app->make(Factory::class)->registerComponents();
+                    } catch (\Exception $e) {}
                 }
             });
         }


### PR DESCRIPTION
The fix introduced in #276 calls registerComponents() on every console command via runningInConsole(). This was needed because php artisan optimize compiles views before the ViewFactory is resolved, so icon components weren't registered yet.
                                                                                                                                                                                                                                                                                                                             
However, this causes a performance regression on serverless environments like AWS Lambda (via Laravel Vapor). Scanning thousands of SVG files adds delay (seconds to minutes) to every CLI invocation, including commands like schedule:run.                                                                                                                                                                                                                                                                                   
                  
This PR scopes the registration to only the commands that actually need it: optimize, view:cache, and icons:cache. These are the only commands that compile Blade views and would encounter the original error. 