### PR TITLE
Optimized `php artisan icons:cache`

### DIFF
--- a/src/BladeIconsServiceProvider.php
+++ b/src/BladeIconsServiceProvider.php
@@ -67,12 +67,13 @@ final class BladeIconsServiceProvider extends ServiceProvider
         });
 
         // Ensure components are registered during console commands (like optimize)
-        // that may compile views before ViewFactory is resolved
+        // that compile views before ViewFactory is resolved. `icons:cache` is
+        // intentionally excluded: it only writes the manifest, so pre-registering
+        // every component would duplicate the filesystem scan and add thousands of
+        // unnecessary Blade::component() calls when large icon packs are installed.
         if ($this->app->runningInConsole() && ! $this->app->environment('testing')) {
             $this->app->booted(function (Application $app) {
-                // Only register components for commands that compile views, to avoid
-                // scanning all icon files on every CLI invocation.
-                if (in_array($_SERVER['argv'][1] ?? null, ['optimize', 'view:cache', 'icons:cache'])) {
+                if (in_array($_SERVER['argv'][1] ?? null, ['optimize', 'view:cache'])) {
                     try {
                         $app->make(Factory::class)->registerComponents();
                     } catch (\Exception $e) {

--- a/src/IconsManifest.php
+++ b/src/IconsManifest.php
@@ -5,9 +5,12 @@ declare(strict_types=1);
 namespace BladeUI\Icons;
 
 use Exception;
+use FilesystemIterator;
 use Illuminate\Contracts\Filesystem\Factory as FilesystemFactory;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Str;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
 use Symfony\Component\Finder\SplFileInfo;
 
 final class IconsManifest
@@ -33,33 +36,83 @@ final class IconsManifest
 
         foreach ($sets as $name => $set) {
             $icons = [];
+            $disk = $set['disk'] ?? null;
 
             foreach ($set['paths'] as $path) {
-                $seen = [];
+                $found = $disk
+                    ? $this->scanDisk($disk, $path)
+                    : $this->scanLocal($path);
 
-                foreach ($this->filesystem($set['disk'] ?? null)->allFiles($path) as $file) {
-                    if ($file instanceof SplFileInfo) {
-                        if ($file->getExtension() !== 'svg') {
-                            continue;
-                        }
+                sort($found);
 
-                        $seen[$this->format($file->getPathName(), $path)] = true;
-                    } else {
-                        if (! Str::endsWith($file, '.svg')) {
-                            continue;
-                        }
-
-                        $seen[$this->format($file, $path)] = true;
-                    }
-                }
-
-                $icons[$path] = array_keys($seen);
+                $icons[$path] = $found;
             }
 
             $compiled[$name] = array_filter($icons);
         }
 
         return $compiled;
+    }
+
+    /**
+     * Fast local-filesystem scan. Bypasses Symfony Finder (used by
+     * Illuminate\Filesystem\Filesystem::allFiles) because it adds significant
+     * per-file overhead for large icon libraries where a single set can hold
+     * tens of thousands of SVGs.
+     */
+    private function scanLocal(string $path): array
+    {
+        if (! is_dir($path)) {
+            return [];
+        }
+
+        $seen = [];
+        $prefixLength = strlen($path) + 1;
+
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($path, FilesystemIterator::SKIP_DOTS)
+        );
+
+        foreach ($iterator as $file) {
+            $pathname = $file->getPathname();
+
+            if (substr($pathname, -4) !== '.svg') {
+                continue;
+            }
+
+            $relative = substr($pathname, $prefixLength, -4);
+
+            if (DIRECTORY_SEPARATOR !== '.') {
+                $relative = str_replace(DIRECTORY_SEPARATOR, '.', $relative);
+            }
+
+            $seen[$relative] = true;
+        }
+
+        return array_keys($seen);
+    }
+
+    private function scanDisk(string $disk, string $path): array
+    {
+        $seen = [];
+
+        foreach ($this->filesystem($disk)->allFiles($path) as $file) {
+            if ($file instanceof SplFileInfo) {
+                if ($file->getExtension() !== 'svg') {
+                    continue;
+                }
+
+                $seen[$this->format($file->getPathName(), $path)] = true;
+            } else {
+                if (! Str::endsWith($file, '.svg')) {
+                    continue;
+                }
+
+                $seen[$this->format($file, $path)] = true;
+            }
+        }
+
+        return array_keys($seen);
     }
 
     /**

--- a/src/IconsManifest.php
+++ b/src/IconsManifest.php
@@ -35,7 +35,7 @@ final class IconsManifest
             $icons = [];
 
             foreach ($set['paths'] as $path) {
-                $icons[$path] = [];
+                $seen = [];
 
                 foreach ($this->filesystem($set['disk'] ?? null)->allFiles($path) as $file) {
                     if ($file instanceof SplFileInfo) {
@@ -43,17 +43,17 @@ final class IconsManifest
                             continue;
                         }
 
-                        $icons[$path][] = $this->format($file->getPathName(), $path);
+                        $seen[$this->format($file->getPathName(), $path)] = true;
                     } else {
                         if (! Str::endsWith($file, '.svg')) {
                             continue;
                         }
 
-                        $icons[$path][] = $this->format($file, $path);
+                        $seen[$this->format($file, $path)] = true;
                     }
                 }
 
-                $icons[$path] = array_unique($icons[$path]);
+                $icons[$path] = array_keys($seen);
             }
 
             $compiled[$name] = array_filter($icons);
@@ -105,9 +105,11 @@ final class IconsManifest
             throw new Exception("The {$dirname} directory must be present and writable.");
         }
 
+        $this->manifest = $this->build($sets);
+
         $this->filesystem->replace(
             $this->manifestPath,
-            '<?php return '.var_export($this->build($sets), true).';',
+            '<?php return '.var_export($this->manifest, true).';',
         );
     }
 }


### PR DESCRIPTION
## Summary

Dramatically speeds up `php artisan icons:cache` (and any other codepath that hits `IconsManifest::build()`) for apps with many icon sets. In a real-world setup with ~12 sets totaling tens of thousands of SVGs, `icons:cache` dropped from **30+ seconds to under a second**. At the same time it fixes an OOM that occurs on large libraries at PHP's default `memory_limit`.

## Why it was slow

`IconsManifest::build()` walked every icon set using `Illuminate\Filesystem\Filesystem::allFiles()`, which is built on top of Symfony Finder. Finder is not designed for this workload:

- Every file is wrapped in a `Symfony\Component\Finder\SplFileInfo` and re-`stat()`ed.
- Regex / sort / filter layers run per file.
- `allFiles()` internally calls `iterator_to_array(...)`, so it materializes the **entire** file list in memory before returning — which OOMs at the PHP default `memory_limit` of 128M on libraries in the ~20k+ SVG range.

On top of that, the service provider was pre-registering Blade components during `icons:cache` (duplicating the scan) and `IconsManifest::build()` was using `array_unique()` on a growing array per path.

## What changed

### `src/IconsManifest.php`

- `build()` now dispatches to one of two scanners:
  - **`scanLocal($path)`** (no `disk` configured) — uses a plain `RecursiveDirectoryIterator` with `FilesystemIterator::SKIP_DOTS`. Results are streamed, filtered by `.svg` suffix, and the relative name is built with `substr` / `str_replace` instead of the previous `Str::of(...)->after(...)->replace(...)->basename(...)` chain.
  - **`scanDisk($disk, $path)`** — preserves existing Flysystem behavior for configured disks.
- Deduplication now uses a hashmap (`$seen[$name] = true` + `array_keys`) instead of `array_unique()`.
- Results are sorted once per path so the manifest remains deterministic (the existing fixture `tests/fixtures/generated-manifest.php` still matches byte-for-byte).
- `write()` caches the built manifest on `$this->manifest` so a later `getManifest()` call in the same request doesn't rescan.

### `src/BladeIconsServiceProvider.php`

- Scoped the `booted()` component pre-registration hook to just `optimize` and `view:cache`. The previous list included `icons:cache`, which forced a second full directory scan and thousands of `Blade::component()` calls every time the manifest was rebuilt.

## Benchmarks

Synthetic scan of an SVG-only tree on the same box, PHP 8.4, warm cache:

| Files  | Old (Finder)            | New (RDI) | Speedup |
| -----: | ----------------------- | --------: | ------: |
| 20,000 | 0.35 s *(OOMs at 128M)* |   0.010 s |    ~35× |
| 60,000 | 2.54 s                  |   0.028 s |    ~92× |

Real-world impact reported by a user running ~12 large sets: `php artisan icons:cache` went from **~30 s → sub-second**.

## Compatibility

- No public API changes.
- Remote / Flysystem disks keep the original code path via `scanDisk()`.
- Manifest output is byte-identical for the repo's own fixtures; sort order is preserved.
- The existing test suite (75 tests, 133 assertions) passes unchanged.